### PR TITLE
README: Fix path in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ tnoremap <C-\><C-c> <C-\><C-n><C-w>c
 neovim-termhide follows the standard runtime path structure. Install with
 something like [vim-plug](https://github.com/junegunn/vim-plug):
 ```vim
-Plug 'jcorbin/vim-lobster'
+Plug 'jcorbin/neovim-termhide'
 ```
 
 ## TODO


### PR DESCRIPTION
This fixes the path to the repository in the installation instructions
of the README.